### PR TITLE
Updated chartist to the latest available version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "dependencies": {
-    "chartist": "~0.3.1",
+    "chartist": "~0.4.3",
     "angular": "^1.2.23"
   },
   "devDependencies": {


### PR DESCRIPTION
I have no idea how MR works in bower world, but I've updated the version locally and it installed me new Chartist and my charts are working better and now labelInterpolationFnc is handling correctly.
